### PR TITLE
Relational hotlinkTextAttr

### DIFF
--- a/LinkableBehavior.php
+++ b/LinkableBehavior.php
@@ -228,7 +228,7 @@ class LinkableBehavior extends Behavior
     {
         $text = is_null($this->hotlinkTextAttr)
             ? Url::to($this->getUrlRoute($action, $params), $this->useAbsoluteUrl)
-            : $this->owner->{$this->hotlinkTextAttr};
+            : ArrayHelper::getValue($this->owner, $this->hotlinkTextAttr);
 
         return $this->disableHotlink
             ? Html::tag('span', $text, $options)


### PR DESCRIPTION
In some use cases it would be helpful to allow `hotlinkTextAttr` to reference an attribute in other Active Record class via relation methods.

For example, reference to a `User::username` from `Profile` class.  

```php
namespace app\models;

use yii\db\ActiveRecord;
use locustv2\behaviors\LinkableBehavior;

class Profile extends ActiveRecord
{
  //...

    public function behaviors()
    {
        return ArrayHelper::merge(parent::behaviors(), [
            [
                'class' => LinkableBehavior::className(),
                'route' => '/profile',
                'defaultAction' => 'view',
                'hotlinkTextAttr' => 'user.username',
                'defaultParams' => function ($record) {
                    return [
                        'id' => $record->id,
                    ];
                },
            ]
        ]);
    }
}
```